### PR TITLE
feat: add server tracer options

### DIFF
--- a/options.go
+++ b/options.go
@@ -16,4 +16,59 @@
 
 package prometheus
 
+import (
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
 var defaultBuckets = []float64{5000, 10000, 25000, 50000, 100000, 250000, 500000, 1000000}
+
+// Option opts for monitor prometheus
+type Option interface {
+	apply(cfg *config)
+}
+
+type option func(cfg *config)
+
+func (fn option) apply(cfg *config) {
+	fn(cfg)
+}
+
+type config struct {
+	buckets           []float64
+	enableGoCollector bool
+	registry          *prom.Registry
+}
+
+func defaultConfig() *config {
+	return &config{
+		buckets:           defaultBuckets,
+		enableGoCollector: false,
+		registry:          prom.NewRegistry(),
+	}
+
+}
+
+// WithEnableGoCollector enable go collector
+func WithEnableGoCollector(enable bool) Option {
+	return option(func(cfg *config) {
+		cfg.enableGoCollector = enable
+	})
+}
+
+// WithHistogramBuckets define your custom histogram buckets base on your biz
+func WithHistogramBuckets(buckets []float64) Option {
+	return option(func(cfg *config) {
+		if len(buckets) > 0 {
+			cfg.buckets = buckets
+		}
+	})
+}
+
+// WithRegistry define your custom registry
+func WithRegistry(registry *prom.Registry) Option {
+	return option(func(cfg *config) {
+		if registry != nil {
+			cfg.registry = registry
+		}
+	})
+}

--- a/options.go
+++ b/options.go
@@ -45,7 +45,6 @@ func defaultConfig() *config {
 		enableGoCollector: false,
 		registry:          prom.NewRegistry(),
 	}
-
 }
 
 // WithEnableGoCollector enable go collector

--- a/trace.go
+++ b/trace.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cloudwego/hertz/pkg/common/tracer"
 	"github.com/cloudwego/hertz/pkg/common/tracer/stats"
 	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
@@ -72,8 +73,15 @@ func (s *serverTracer) Finish(ctx context.Context, c *app.RequestContext) {
 }
 
 // NewServerTracer provides tracer for server access, addr and path is the scrape_configs for prometheus server.
-func NewServerTracer(addr, path string) tracer.Tracer {
-	registry := prom.NewRegistry()
+func NewServerTracer(addr, path string, opts ...Option) tracer.Tracer {
+	cfg := defaultConfig()
+
+	for _, opts := range opts {
+		opts.apply(cfg)
+	}
+
+	registry := cfg.registry
+
 	http.Handle(path, promhttp.HandlerFor(registry, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
 	go func() {
 		if err := http.ListenAndServe(addr, nil); err != nil {
@@ -99,6 +107,10 @@ func NewServerTracer(addr, path string) tracer.Tracer {
 		[]string{labelMethod, labelStatusCode},
 	)
 	registry.MustRegister(serverHandledHistogram)
+
+	if cfg.enableGoCollector {
+		registry.MustRegister(collectors.NewGoCollector())
+	}
 
 	return &serverTracer{
 		serverHandledCounter:   serverHandledCounter,


### PR DESCRIPTION
#### What type of PR is this?

feat: add server tracer options

#### What this PR does / why we need it (English/Chinese):

en: add registry、 buckets、 go collector metrics options
zh: 增加registry、buckets、go collector配置，默认和以前的使用一样

#### Which issue(s) this PR fixes:

